### PR TITLE
Fix high memory usage when download

### DIFF
--- a/handlers/file.go
+++ b/handlers/file.go
@@ -175,7 +175,6 @@ func (h *FileRoutesHandler) GetFile(c *fiber.Ctx) error {
 		}
 		return NewHTTPError(h.log, fiber.StatusInternalServerError, "unable to check if file exist", err)
 	}
-
 	// Get encrypted file from storage manager
 	file, err := h.storageManager.OpenFile(fileInfo.ID)
 	if err != nil {
@@ -184,14 +183,9 @@ func (h *FileRoutesHandler) GetFile(c *fiber.Ctx) error {
 
 	if fileInfo.Encrypted {
 		// Decrypt file if encrypted
-		err = h.encryptionManager.Decrypt(file, fileInfo.Nonce, c)
+		file, err = h.encryptionManager.Decrypt(file, fileInfo.Nonce)
 		if err != nil {
 			return NewHTTPError(h.log, fiber.StatusInternalServerError, "unable to decrypt", err)
-		}
-	} else {
-		// Copy file content to response
-		if _, err := io.Copy(c, file); err != nil {
-			return NewHTTPError(h.log, fiber.StatusInternalServerError, "unable to copy file content to response", err)
 		}
 	}
 
@@ -204,7 +198,7 @@ func (h *FileRoutesHandler) GetFile(c *fiber.Ctx) error {
 	c.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, fileInfo.Filename))
 	c.Set("Content-Type", "application/octet-stream")
 
-	return nil
+	return c.SendStream(file, int(fileInfo.FileSize))
 }
 
 // GetOwnFiles handlers

--- a/service/encrypt/manager.go
+++ b/service/encrypt/manager.go
@@ -4,5 +4,5 @@ import "io"
 
 type Manager interface {
 	Encrypt(input io.Reader) (io.Reader, string, error)
-	Decrypt(input io.Reader, nonceString string, output io.Writer) error
+	Decrypt(input io.Reader, nonceString string) (io.Reader, error)
 }

--- a/service/encrypt/sio_test.go
+++ b/service/encrypt/sio_test.go
@@ -32,9 +32,11 @@ func TestEncryptionAndDecryption(t *testing.T) {
 	require.NotEqual(t, inputString, b.String())
 
 	// Decrypt the reader (Somehow didn't works)
-	//decryptedWriter := new(strings.Builder)
-	//err = sioManager.Decrypt(encryptedReader, nonce, decryptedWriter)
-	//sugarLogger.Info("n", decryptedWriter.Len())
+	//decryptedReader, err := sioManager.Decrypt(encryptedReader, nonce)
 	//require.NoError(t, err)
-	//require.Equal(t, inputString, decryptedWriter.String())
+	////require.Equal(t, inputString, )
+	//buf := new(strings.Builder)
+	//_, err = io.Copy(buf, decryptedReader)
+	//require.NoError(t, err)
+	//require.Equal(t, inputString, buf.String())
 }


### PR DESCRIPTION
- Change `io.Copy` to using `c.SendStream()`
- Change output of  `Decrypt` func of `SIOManager` to return `io.Reader`